### PR TITLE
Add before end markers

### DIFF
--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -192,6 +192,18 @@ class ActionRegressionTest {
                 .build()
                 .toString()
         )
+
+        assertEquals(
+            "ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=-0.5), A])" +
+                    "])",
+            base
+                .afterTime(-0.5, LabelAction("A"))
+                .lineToX(10.0)
+                .build()
+                .toString()
+        )
     }
 
     @Test
@@ -291,5 +303,13 @@ class ActionRegressionTest {
                 .build()
                 .toString()
         )
+
+        assertFails {
+            base
+                .afterDisp(-2.5, LabelAction("A"))
+                .lineToX(10.0)
+                .build()
+                .toString()
+        }
     }
 }

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -158,8 +158,8 @@ class ActionRegressionTest {
                     "SequentialAction(initialActions=[SleepAction(dt=2.32842712474619), A])" +
                     "])",
             base
-                .beforeEndTime(0.5, LabelAction("A"))
                 .lineToX(20.0)
+                .afterTime(-0.5, LabelAction("A"))
                 .lineToXLinearHeading(30.0, Math.PI / 2)
                 .build()
                 .toString()
@@ -172,8 +172,8 @@ class ActionRegressionTest {
                     "])])",
             base
                 .lineToX(10.0)
-                .beforeEndTime(0.5, LabelAction("A"))
                 .lineToXLinearHeading(20.0, Math.PI / 2)
+                .afterTime(-0.5, LabelAction("A"))
                 .lineToX(30.0)
                 .build()
                 .toString(),
@@ -187,8 +187,8 @@ class ActionRegressionTest {
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)
-                .beforeEndTime(0.5, LabelAction("A"))
                 .lineToX(30.0)
+                .afterTime(-0.5, LabelAction("A"))
                 .build()
                 .toString()
         )
@@ -257,8 +257,8 @@ class ActionRegressionTest {
                     "SequentialAction(initialActions=[SleepAction(dt=2.121320343559643), A])" +
                     "])",
             base
-                .beforeEndDisp(2.5, LabelAction("A"))
                 .lineToX(20.0)
+                .afterDisp(-2.5, LabelAction("A"))
                 .lineToXLinearHeading(30.0, Math.PI / 2)
                 .build()
                 .toString()
@@ -271,8 +271,8 @@ class ActionRegressionTest {
                     "])])",
             base
                 .lineToX(10.0)
-                .beforeEndDisp(2.5, LabelAction("A"))
                 .lineToXLinearHeading(20.0, Math.PI / 2)
+                .afterDisp(-2.5, LabelAction("A"))
                 .lineToX(30.0)
                 .build()
                 .toString(),
@@ -286,8 +286,8 @@ class ActionRegressionTest {
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)
-                .beforeEndDisp(2.5, LabelAction("A"))
                 .lineToX(30.0)
+                .afterDisp(-2.5, LabelAction("A"))
                 .build()
                 .toString()
         )

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -154,9 +154,9 @@ class ActionRegressionTest {
     fun testTrajectoryTimeNegativeMarkers() {
         assertEquals(
             "ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=2.32842712474619), A])" +
-                    "])",
+                "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=2.32842712474619), A])" +
+                "])",
             base
                 .lineToX(20.0)
                 .afterTime(-0.5, LabelAction("A"))
@@ -167,9 +167,9 @@ class ActionRegressionTest {
 
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=1.4999999999999993), A])" +
-                    "])])",
+                "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=1.4999999999999993), A])" +
+                "])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)
@@ -181,9 +181,9 @@ class ActionRegressionTest {
 
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=1.5000000000000009), A])" +
-                    "])])",
+                "SequentialAction(initialActions=[Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=1.5000000000000009), A])" +
+                "])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)
@@ -195,9 +195,9 @@ class ActionRegressionTest {
 
         assertEquals(
             "ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=-0.5), A])" +
-                    "])",
+                "SequentialAction(initialActions=[Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=-0.5), A])" +
+                "])",
             base
                 .afterTime(-0.5, LabelAction("A"))
                 .lineToX(10.0)
@@ -265,9 +265,9 @@ class ActionRegressionTest {
     fun testTrajectoryDispNegativeMarkers() {
         assertEquals(
             "ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=2.121320343559643), A])" +
-                    "])",
+                "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=2.121320343559643), A])" +
+                "])",
             base
                 .lineToX(20.0)
                 .afterDisp(-2.5, LabelAction("A"))
@@ -278,9 +278,9 @@ class ActionRegressionTest {
 
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134519), A])" +
-                    "])])",
+                "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134519), A])" +
+                "])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)
@@ -292,9 +292,9 @@ class ActionRegressionTest {
 
         assertEquals(
             "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
-                    "SequentialAction(initialActions=[Trajectory]), " +
-                    "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134532), A])" +
-                    "])])",
+                "SequentialAction(initialActions=[Trajectory]), " +
+                "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134532), A])" +
+                "])])",
             base
                 .lineToX(10.0)
                 .lineToXLinearHeading(20.0, Math.PI / 2)

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -141,9 +141,54 @@ class ActionRegressionTest {
         assertEquals(
             "ParallelAction(initialActions=[SequentialAction(initialActions=[]), " +
                 "SequentialAction(initialActions=[" +
-                "SleepAction(dt=1.0), a])])",
+                "SleepAction(dt=1.0), A])])",
             base
-                .afterTime(1.0, LabelAction("a"))
+                .afterTime(1.0, LabelAction("A"))
+                .build()
+                .toString()
+        )
+    }
+
+    @Test
+    @Strictfp
+    fun testTrajectoryTimeNegativeMarkers() {
+        assertEquals(
+            "ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=2.32842712474619), A])" +
+                    "])",
+            base
+                .beforeEndTime(0.5, LabelAction("A"))
+                .lineToX(20.0)
+                .lineToXLinearHeading(30.0, Math.PI / 2)
+                .build()
+                .toString()
+        )
+
+        assertEquals(
+            "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=1.4999999999999993), A])" +
+                    "])])",
+            base
+                .lineToX(10.0)
+                .beforeEndTime(0.5, LabelAction("A"))
+                .lineToXLinearHeading(20.0, Math.PI / 2)
+                .lineToX(30.0)
+                .build()
+                .toString(),
+        )
+
+        assertEquals(
+            "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=1.5000000000000009), A])" +
+                    "])])",
+            base
+                .lineToX(10.0)
+                .lineToXLinearHeading(20.0, Math.PI / 2)
+                .beforeEndTime(0.5, LabelAction("A"))
+                .lineToX(30.0)
                 .build()
                 .toString()
         )
@@ -198,6 +243,51 @@ class ActionRegressionTest {
                 .afterDisp(1.0, LabelAction("A"))
                 .lineToX(0.25)
                 .lineToXLinearHeading(10.25, PI / 4)
+                .build()
+                .toString()
+        )
+    }
+
+    @Test
+    @Strictfp
+    fun testTrajectoryDispNegativeMarkers() {
+        assertEquals(
+            "ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=2.121320343559643), A])" +
+                    "])",
+            base
+                .beforeEndDisp(2.5, LabelAction("A"))
+                .lineToX(20.0)
+                .lineToXLinearHeading(30.0, Math.PI / 2)
+                .build()
+                .toString()
+        )
+
+        assertEquals(
+            "SequentialAction(initialActions=[Trajectory, ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory, Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134519), A])" +
+                    "])])",
+            base
+                .lineToX(10.0)
+                .beforeEndDisp(2.5, LabelAction("A"))
+                .lineToXLinearHeading(20.0, Math.PI / 2)
+                .lineToX(30.0)
+                .build()
+                .toString(),
+        )
+
+        assertEquals(
+            "SequentialAction(initialActions=[Trajectory, Trajectory, ParallelAction(initialActions=[" +
+                    "SequentialAction(initialActions=[Trajectory]), " +
+                    "SequentialAction(initialActions=[SleepAction(dt=1.2928932188134532), A])" +
+                    "])])",
+            base
+                .lineToX(10.0)
+                .lineToXLinearHeading(20.0, Math.PI / 2)
+                .beforeEndDisp(2.5, LabelAction("A"))
+                .lineToX(30.0)
                 .build()
                 .toString()
         )


### PR DESCRIPTION
Adds the `beforeEndTime` and `beforeEndDisp` markers, which executes the given action a given `dt` or `ds` before the end of the current / next trajectory segment. I believe this is more correct and functional compared to #123, but I did have to change the signature of `MarkerFactory#make`. This code has been tested in production on my team's auto.