### PR TITLE
Remove local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 out
 .project
 .classpath
+local.properties
 
 *.iml
 *.ipr

--- a/road-runner/local.properties
+++ b/road-runner/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun Oct 29 20:17:56 PDT 2023
-sdk.dir=/Users/ryan/Library/Android/sdk


### PR DESCRIPTION
This file is unique to each computer. It points to the location of the Android SDK. It should not be checked into git. It probably doesn't cause any issues because this repo doesn't do anything with the Android SDK, but it's still better practice to not have it there. This PR removes it and adds it to the .gitignore.