### PR TITLE
add WaitUntilAction

### DIFF
--- a/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
+++ b/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
@@ -144,8 +144,8 @@ fun interface ConditionalFunction {
  */
 data class WaitUntilAction(
     val f: ConditionalFunction,
-    val minTime: Double,
-    val maxTime: Double
+    val minTime: Double = 0.0,
+    val maxTime: Double = Double.MAX_VALUE
 ) : Action {
     private var beginTs = -1.0;
 

--- a/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
+++ b/road-runner/actions/src/main/kotlin/com/acmerobotics/roadrunner/Actions.kt
@@ -134,6 +134,38 @@ class InstantAction(val f: InstantFunction) : Action {
     }
 }
 
+fun interface ConditionalFunction {
+    fun condition(): Boolean
+}
+
+/**
+ * Blocking action that waits until [f] is true, for a minimum duration of [minTime]
+ * and a maximum duration of [maxTime].
+ */
+data class WaitUntilAction(
+    val f: ConditionalFunction,
+    val minTime: Double,
+    val maxTime: Double
+) : Action {
+    private var beginTs = -1.0;
+
+    override fun run(p: TelemetryPacket): Boolean {
+        val t = if (beginTs < 0) {
+            beginTs = now()
+            0.0
+        } else {
+            now() - beginTs
+        }
+
+        if (t < minTime) return true
+        if (t >= maxTime) return false
+
+        return !f.condition()
+    }
+
+    override fun preview(fieldOverlay: Canvas) {}
+}
+
 /**
  * Null action that does nothing.
  */

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionRegressionTest.kt
@@ -55,6 +55,11 @@ fun sexpFromAction(a: Action): Sexp =
         is SleepAction -> Sexp.list(Sexp.Atom("sleep"), Sexp.Atom(String.format("%.10f", a.dt)))
         is SequentialAction -> Sexp.list(listOf(Sexp.Atom("seq")) + a.initialActions.map(::sexpFromAction))
         is ParallelAction -> Sexp.list(listOf(Sexp.Atom("par")) + a.initialActions.map(::sexpFromAction))
+        is WaitUntilAction -> Sexp.list(
+            Sexp.atom("waitUntil"),
+            Sexp.Atom(String.format("%.10f", a.minTime)),
+            Sexp.Atom(String.format("%.10f", a.maxTime))
+        )
         is NullAction -> Sexp.Atom("null")
         else -> Sexp.Atom("unk")
     }

--- a/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionsTest.kt
+++ b/road-runner/actions/src/test/kotlin/com/acmerobotics/roadrunner/ActionsTest.kt
@@ -120,4 +120,22 @@ class ActionsTest {
         )
         assertEquals(listOf(1), steps)
     }
+
+    @Test
+    fun testWaitUntilCondition() {
+        var condition = false
+        var count = 0
+
+        assertEquals(
+            2,
+            runBlockingCount(
+                WaitUntilAction({
+                    count++
+                    condition = count >= 3
+                    condition
+                })
+            )
+        )
+        assert(condition)
+    }
 }


### PR DESCRIPTION
Add the `WaitUntilAction`, which blocks until a certain condition is met.

## Example use case:
```java
public Action actionShoot(double delay) {
    return new SequentialAction(
            new InstantAction(() -> intake.in()),
            new InstantAction(() -> outtake.enable()),
            new WaitUntilAction(() -> outtake.inTolerance()), // <- here
            new InstantAction(() -> intake.openGate()),
            new SleepAction(delay),
            new InstantAction(() -> intake.closeGate()),
            new InstantAction(() -> intake.store()),
            new InstantAction(() -> outtake.disable())
    );
}
```
This code waits for the flywheel to reach full velocity before opening the gate.